### PR TITLE
[ENHANCEMENT] Save latest client response to thread safe class variable

### DIFF
--- a/lib/ebay_api/client.rb
+++ b/lib/ebay_api/client.rb
@@ -1,6 +1,7 @@
 module EbayAPI
   class Client
     include HTTParty
+    thread_mattr_accessor :last_response, instance_accessor: false
 
     def self.default_options
       Thread.current["EbayAPI"] || raise("Session has not been activated yet")

--- a/lib/ebay_api/concerns/singleton.rb
+++ b/lib/ebay_api/concerns/singleton.rb
@@ -14,7 +14,8 @@ module EbayAPI
         headers =  EbayAPI::Client.default_options[:headers].merge({
           "X-EBAY-API-CALL-NAME" => action.to_s.camelize
         })
-        EbayAPI::Client.post(api_endpoint, { body: body, headers: headers })
+        EbayAPI::Client.last_response = EbayAPI::Client.post(api_endpoint, { body: body, headers: headers })
+        EbayAPI::Client.last_response
       end
 
       def api_endpoint


### PR DESCRIPTION
Not using per thread registry as : https://api.rubyonrails.org/classes/ActiveSupport/PerThreadRegistry.html

NOTE: This approach has been deprecated for end-user code in favor of thread_mattr_accessor and friends. Please use that approach instead.


Using thread_mattr_accessor instead. 


Im actually thinking saving entire request might not be worth it. Thinking of saving just `has more` or `pagination result`