### PR TITLE
[ENHANCEMENT] Ship Line Items method for order

### DIFF
--- a/lib/ebay_api/resources/api/order.rb
+++ b/lib/ebay_api/resources/api/order.rb
@@ -232,20 +232,28 @@ module EbayAPI
     end
 
     def self.ship_line_item(order_line_item_id, shipment_tracking_number, shipping_carrier_used)
-      response = complete_sale(order_line_item_id, shipment_tracking_number, shipping_carrier_used)
+      response = complete_sale(nil, order_line_item_id, shipment_tracking_number, shipping_carrier_used)
       raise EbayAPI::Error if response['CompleteSaleResponse']['Ack'] != 'Success'
 
       return true
     end
 
-    private_class_method def self.complete_sale(order_line_item_id, shipment_tracking_number, shipping_carrier_used)
+    def self.ship_order(order_id, shipment_tracking_number, shipping_carrier_used)
+      response = complete_sale(order_id, nil, shipment_tracking_number, shipping_carrier_used)
+      raise EbayAPI::Error if response['CompleteSaleResponse']['Ack'] != 'Success'
+
+      return true
+    end
+
+    private_class_method def self.complete_sale(order_id, order_line_item_id, tracking_number, carrier_used)
       body = Nokogiri::XML::Builder.new(:encoding => 'UTF-8') do |xml|
         xml.CompleteSaleRequest("xmlns" => "urn:ebay:apis:eBLBaseComponents") do
-          xml.OrderLineItemID order_line_item_id
+          xml.OrderID order_id if order_id
+          xml.OrderLineItemID order_line_item_id if order_line_item_id
           xml.Shipment {
             xml.ShipmentTrackingDetails {
-              xml.ShipmentTrackingNumber shipment_tracking_number
-              xml.ShippingCarrierUsed shipping_carrier_used
+              xml.ShipmentTrackingNumber tracking_number
+              xml.ShippingCarrierUsed carrier_used
             }
             xml.ShippedTime Time.now.utc
           }

--- a/lib/ebay_api/resources/api/order.rb
+++ b/lib/ebay_api/resources/api/order.rb
@@ -208,7 +208,7 @@ module EbayAPI
           else
             xml.CreateTimeFrom params[:create_time_from] if params[:create_time_from]
             xml.CreateTimeTo params[:create_time_to] if  params[:create_time_to]
-            xml.ModTimeFrom  params[:mod_time_to] if params[:mod_time_to]
+            xml.ModTimeFrom  params[:mod_time_from] if params[:mod_time_from]
             xml.ModTimeTo    params[:mod_time_to] if params[:mod_time_to]
             xml.NumberOfDays params[:number_of_days] if params[:number_of_days]
           end


### PR DESCRIPTION
EbayAPI::Order.ship_line_items([order_line_item_ids], shipment_tracking_number, shipping_carrier)

Example usage:
EbayAPI::Order.ship_line_items(['110514344625-29021920001'],'444444', 'FedEx')


Possible Alternates:
- Put it as a create endpoint in Shipping details? 
- Call it create_fulfillment instead (EbayAPI::Order.create_fulfillment)
