### PR TITLE
[BUGFIX] always deconstruct array into single element

### DIFF
--- a/lib/ebay_api/resources/api/order.rb
+++ b/lib/ebay_api/resources/api/order.rb
@@ -202,7 +202,7 @@ module EbayAPI
 
     def self.get_orders(params = {})
       # TODO : Ensure Options can be used instead of order_ids
-      return if (params[:order_ids].nil? && params[:create_time_from].nil? && params[:mod_time_from].nil?)
+      return [] if (params[:order_ids].nil? && params[:create_time_from].nil? && params[:mod_time_from].nil?)
 
       body = Nokogiri::XML::Builder.new(:encoding => 'UTF-8') do |xml|
         xml.GetOrdersRequest("xmlns" => "urn:ebay:apis:eBLBaseComponents") do

--- a/lib/ebay_api/resources/api/order.rb
+++ b/lib/ebay_api/resources/api/order.rb
@@ -238,8 +238,7 @@ module EbayAPI
     end
 
     def self.get_order(order_id)
-      orders = get_orders({order_ids: Array.wrap(order_id)})
-      orders.one? ? orders.first : orders
+      get_orders({order_ids: Array.wrap(order_id)}).first
     end
 
     def self.ship_line_item(order_line_item_id, shipment_tracking_number, shipping_carrier_used, shipped_time = Time.now.utc)


### PR DESCRIPTION
Assuming `get_orders` always return an array, `get_order` should always deconstruct the result into single element.

**BEFORE**
when `get_orders` => [] , then `get_order` => []
when `get_orders` => [1] , then `get_order` => 1
when `get_orders` => [1, 2] , then `get_order` => [1, 2]

**AFTER**
when `get_orders` => [] , then `get_order` => nil
when `get_orders` => [1] , then `get_order` => 1
when `get_orders` => [1, 2] , then `get_order` => 1