### PR TITLE
[BUGFIX] Payee is not an array anymore

### DIFF
--- a/lib/ebay_api/resources/shared/monetary_details.rb
+++ b/lib/ebay_api/resources/shared/monetary_details.rb
@@ -6,7 +6,11 @@ module EbayAPI
     attribute? :payments do
       attribute? :payment, Types::Array do
         attribute? :fee_or_credit_amount, EbayAPI::Amount
-        attribute? :payee, Types::Array do
+        attribute? :payee do
+          attribute? :type, Types::String.optional
+          attribute? :value, Types::String.optional
+        end
+        attribute? :payer do
           attribute? :type, Types::String.optional
           attribute? :value, Types::String.optional
         end


### PR DESCRIPTION
https://developer.ebay.com/devzone/xml/docs/reference/ebay/types/PaymentTransactionType.html

There seems to have been some changes on eBay API that is not applied onto our gem.

```
<MonetaryDetails>
<Payments>
<Payment>
  <PaymentStatus>Succeeded</PaymentStatus>
  <Payer type="eBayUser">sample</Payer>
  <Payee type="eBayUser">sample_sample</Payee>
  <PaymentTime>2023-04-10T23:37:51.437Z</PaymentTime>
  <PaymentAmount currencyID="USD">11.53</PaymentAmount>
  <ReferenceID type="ExternalTransactionID">1676079986402</ReferenceID>
</Payment>
</Payments>
</MonetaryDetails>

```